### PR TITLE
feat: improve git command handling with jobs

### DIFF
--- a/lua/zenpai/git_cmd.lua
+++ b/lua/zenpai/git_cmd.lua
@@ -1,48 +1,71 @@
 local M = {}
+local Job = require "plenary.job"
 
-local function run_command(cmd)
-  return table.concat(vim.fn.systemlist(cmd), "\n")
+local function run_command(cmd, opts)
+  opts = opts or {}
+  local result = {}
+  local job = Job:new {
+    command = cmd[1],
+    args = vim.list_slice(cmd, 2),
+    on_stdout = function(_, data)
+      table.insert(result, data)
+    end,
+    on_stderr = function(_, data)
+      if opts.show_error then
+        vim.notify("Error: " .. data, vim.log.levels.ERROR)
+      end
+    end,
+    on_exit = function(_, return_val)
+      if opts.on_exit then
+        opts.on_exit(return_val)
+      end
+    end,
+  }
+
+  job:sync()
+  return table.concat(result, "\n")
 end
 
 function M.is_git_repo()
-  return run_command "git rev-parse --is-inside-work-tree" == "true"
+  local output = run_command { "git", "rev-parse", "--is-inside-work-tree" }
+  return output == "true"
 end
 
 function M.has_changes()
-  return run_command "git status --porcelain" ~= ""
+  local output = run_command { "git", "status", "--porcelain" }
+  return output ~= ""
 end
 
 function M.current_branch()
-  return run_command "git rev-parse --abbrev-ref HEAD"
+  return run_command { "git", "rev-parse", "--abbrev-ref", "HEAD" }
 end
 
 function M.files_to_be_staged()
-  local status = run_command "git status --porcelain"
+  local status = run_command { "git", "status", "--porcelain" }
   if status ~= "" then
     return "Files to be staged:\n" .. status
   else
-    return nil -- No files to stage
+    return nil
   end
 end
 
 function M.stage_files()
-  run_command "git add ."
+  run_command({ "git", "add", "." }, { show_error = true })
 end
 
 function M.commit(commit_msg)
-  vim.notify(commit_msg)
-  run_command('git commit -m "' .. commit_msg .. '"')
+  run_command({ "git", "commit", "-m", commit_msg }, { show_error = true })
   return vim.v.shell_error == 0
 end
 
 function M.create_branch(branch_name)
-  run_command('git checkout -b "' .. branch_name .. '"')
+  run_command({ "git", "checkout", "-b", branch_name }, { show_error = true })
   return vim.v.shell_error == 0
 end
 
 function M.get_diff()
-  local staged_diff = run_command "git diff --staged"
-  local unstaged_diff = run_command "git diff"
+  local staged_diff = run_command { "git", "diff", "--staged" }
+  local unstaged_diff = run_command { "git", "diff" }
   local diff = {}
 
   if staged_diff ~= "" then
@@ -55,5 +78,4 @@ function M.get_diff()
 
   return table.concat(diff, "\n\n")
 end
-
 return M

--- a/lua/zenpai/prompts.lua
+++ b/lua/zenpai/prompts.lua
@@ -2,14 +2,24 @@ local M = {}
 
 function M.commit_msg_prompt(diff)
   local prompt = [[
-    Generate a git commit message based on the output of a diff command.
-    Summarize the change in less than 50 characters
+    Generate a git commit message for the following diff output. Follow these rules:
 
-    Because:
-    - Explain the reasons you made this change
-    - Make a new bullet for each reason
-    - Each line should be under 72 characters
-    - Don't include the "Because:" in the commit.
+    1. First line must:
+      - Start with a type (feat/fix/refactor/style/test/docs/chore)
+      - Use the format: type: description
+      - Be less than 50 characters 
+      - Use imperative mood ("add" not "added")
+
+
+    3. The body must:
+      - Leave one blank line after the title
+      - Limit to key points; avoid unnecessary detail
+      - Wrap lines at 72 characters
+      - Use bullet points ("-") in imperative mood
+      - Mention specific functions, variables, or components changed
+      - Describe *what* was changed and *why* it matters, in brief
+
+    Return only the commit message text.
 
     Here is the diff output:
     ]]


### PR DESCRIPTION
- refactor `run_command` to use `plenary.job` for better asynchronous handling.
- update all git command invocations to use a table format for consistency and improved error handling.
- modify `stage_files`, `commit`, and `create_branch` to show errors when commands fail, enhancing user feedback.
- ensure `is_git_repo`, `has_changes`, `current_branch`, `files_to_be_staged`, and `get_diff` utilize the new `run_command` structure for uniformity.

this change improves the robustness and user experience of the git command functions in the zenpai module.